### PR TITLE
Fix download_data.py, celltrackingchallenge.net download url changed

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     )
 
     download_and_unzip(
-        "http://data.celltrackingchallenge.net/challenge-datasets/Fluo-N2DL-HeLa.zip",
+        "http://data.celltrackingchallenge.net/test-datasets/Fluo-N2DL-HeLa.zip",
         out_path / "hela" / "test",
     )
 


### PR DESCRIPTION
The folder structure for downloads on celltrackingchallenge.net changed.

See: [https://web.archive.org/web/20210725223114/http://celltrackingchallenge.net/2d-datasets/](url)
vs
http://celltrackingchallenge.net/2d-datasets/